### PR TITLE
Add in‑memory DB switch, validation, and full test suite

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 from flask import Flask, render_template, request
 from dotenv import load_dotenv
 from peewee import *
@@ -9,11 +10,21 @@ from urllib.parse import urlencode
 
 load_dotenv()
 app = Flask(__name__)
-mydb = MySQLDatabase(   os.getenv("MYSQL_DATABASE"),
-                        user=os.getenv("MYSQL_USER"),
-                        password=os.getenv("MYSQL_PASSWORD"),
-                        host=os.getenv("MYSQL_HOST"),
-                        port=3306)
+
+# Database configuration - use SQLite for testing, MySQL for production
+if os.getenv("TESTING") == "true":
+    print("Running in test mode")
+    mydb = SqliteDatabase("file:memory?mode=memory&cache=shared", uri=True)
+else:
+    mydb = MySQLDatabase(
+        os.getenv("MYSQL_DATABASE"),
+        user=os.getenv("MYSQL_USER"),
+        password=os.getenv("MYSQL_PASSWORD"),
+        host=os.getenv("MYSQL_HOST"),
+        port=3306,
+    )
+
+EMAIL_RE = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
 class TimelinePost(Model):
     name = CharField()
@@ -109,11 +120,18 @@ def timeline():
 
 @app.route('/api/timeline_post', methods=['POST'])
 def post_time_line_post():
-    name = request.form['name']
-    email = request.form['email']
-    content = request.form['content']
-    timeline_post = TimelinePost.create(name=name, email=email, content=content)
+    name = request.form.get("name", "").strip()
+    email = request.form.get("email", "").strip()
+    content = request.form.get("content", "").strip()
 
+    if not name:
+        return "Invalid name", 400
+    if not content:
+        return "Invalid content", 400
+    if not EMAIL_RE.fullmatch(email):
+        return "Invalid email", 400
+
+    timeline_post = TimelinePost.create(name=name, email=email, content=content)
     return model_to_dict(timeline_post)
 
 @app.route('/api/timeline_post', methods=['GET'])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,69 @@
+import os, unittest
+os.environ["TESTING"] = "true"          # Must be set before importing app
+from app import app
+
+class AppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
+    # ---------- Home page ----------
+    def test_home(self):
+        res = self.client.get("/")
+        self.assertEqual(res.status_code, 200)
+        html = res.get_data(as_text=True)
+        self.assertIn("<title>Declan&#39;s Portfolio</title>", html)
+        self.assertIn("Timeline", html)
+
+    # ---------- /api/timeline_post happy path ----------
+    def test_timeline_api_happy_path(self):
+        # should start empty
+        res = self.client.get("/api/timeline_post")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.get_json()["timeline_posts"], [])
+
+        # insert one post
+        res = self.client.post("/api/timeline_post", data={
+            "name": "John Doe",
+            "email": "john@example.com",
+            "content": "Hello world, I'm John!"
+        })
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.get_json()["name"], "John Doe")
+
+        # check GET now returns exactly one
+        res = self.client.get("/api/timeline_post")
+        self.assertEqual(len(res.get_json()["timeline_posts"]), 1)
+
+    # ---------- Timeline HTML page ----------
+    def test_timeline_page(self):
+        res = self.client.get("/timeline")
+        self.assertEqual(res.status_code, 200)
+        self.assertIn("<title>Timeline</title>", res.get_data(as_text=True))
+
+    # ---------- malformed requests ----------
+    def test_malformed_timeline_post(self):
+        # missing name
+        res = self.client.post("/api/timeline_post", data={
+            "email": "john@example.com",
+            "content": "Hello world, I'm John!"
+        })
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("Invalid name", res.get_data(as_text=True))
+
+        # empty content
+        res = self.client.post("/api/timeline_post", data={
+            "name": "John Doe",
+            "email": "john@example.com",
+            "content": ""
+        })
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("Invalid content", res.get_data(as_text=True))
+
+        # bad email
+        res = self.client.post("/api/timeline_post", data={
+            "name": "John Doe",
+            "email": "not-an-email",
+            "content": "Hello world, I'm John!"
+        })
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("Invalid email", res.get_data(as_text=True)) 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,36 @@
+import unittest
+from peewee import SqliteDatabase
+from app import TimelinePost
+
+MODELS = [TimelinePost]
+test_db = SqliteDatabase(":memory:")
+
+class TestTimelinePost(unittest.TestCase):
+    def setUp(self):
+        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        test_db.connect()
+        test_db.create_tables(MODELS)
+
+    def tearDown(self):
+        test_db.drop_tables(MODELS)
+        test_db.close()
+
+    def test_timeline_post_crud(self):
+        p1 = TimelinePost.create(
+            name="John Doe",
+            email="john@example.com",
+            content="Hello world, I'm John!"
+        )
+        self.assertEqual(p1.id, 1)
+
+        p2 = TimelinePost.create(
+            name="Jane Doe",
+            email="jane@example.com",
+            content="Hello world, I'm Jane!"
+        )
+        self.assertEqual(p2.id, 2)
+
+        posts = list(TimelinePost.select().order_by(TimelinePost.id))
+        self.assertEqual(len(posts), 2)
+        self.assertEqual(posts[0].name, "John Doe")
+        self.assertEqual(posts[1].email, "jane@example.com") 


### PR DESCRIPTION
* Environment‑based DB config  
  * Uses SQLite in‑memory when `TESTING="true"`  
  * Falls back to MySQL otherwise  
* Robust input validation on `/api/timeline_post`  
  * Non‑empty name & content  
  * Regex‑validated email  
  * Returns clear 400 errors on bad input  
* New test suite under `tests/`  
  * `test_db.py` – CRUD on `TimelinePost` with in‑memory DB  
  * `test_app.py` – home page, API happy path, malformed cases, timeline page  
* All tests pass → `python -m unittest discover -v tests`